### PR TITLE
Changed define names to prevent conflicts

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -32,12 +32,12 @@ extern "C" {
 
 // Initialize Class Variables //////////////////////////////////////////////////
 
-uint8_t TwoWire::rxBuffer[BUFFER_LENGTH];
+uint8_t TwoWire::rxBuffer[ARDUINO_WIRE_RX_BUFFER_LENGTH];
 uint8_t TwoWire::rxBufferIndex = 0;
 uint8_t TwoWire::rxBufferLength = 0;
 
 uint8_t TwoWire::txAddress = 0;
-uint8_t TwoWire::txBuffer[BUFFER_LENGTH];
+uint8_t TwoWire::txBuffer[ARDUINO_WIRE_TX_BUFFER_LENGTH];
 uint8_t TwoWire::txBufferIndex = 0;
 uint8_t TwoWire::txBufferLength = 0;
 
@@ -154,8 +154,8 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
   }
 
   // clamp to buffer length
-  if(quantity > BUFFER_LENGTH){
-    quantity = BUFFER_LENGTH;
+  if(quantity > ARDUINO_WIRE_RX_BUFFER_LENGTH){
+    quantity = ARDUINO_WIRE_RX_BUFFER_LENGTH;
   }
   // perform blocking read into buffer
   uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop);
@@ -242,7 +242,7 @@ size_t TwoWire::write(uint8_t data)
   if(transmitting){
   // in master transmitter mode
     // don't bother if buffer is full
-    if(txBufferLength >= BUFFER_LENGTH){
+    if(txBufferLength >= ARDUINO_WIRE_TX_BUFFER_LENGTH){
       setWriteError();
       return 0;
     }

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -26,8 +26,14 @@
 #include <inttypes.h>
 #include "Stream.h"
 
-#ifndef BUFFER_LENGTH
-#define BUFFER_LENGTH 32
+// Size of the twi transmit buffer in bytes
+#ifndef ARDUINO_WIRE_TX_BUFFER_LENGTH
+#define ARDUINO_WIRE_TX_BUFFER_LENGTH 32
+#endif
+
+// Size of the twi receive buffer in bytes
+#ifndef ARDUINO_WIRE_RX_BUFFER_LENGTH
+#define ARDUINO_WIRE_RX_BUFFER_LENGTH 32
 #endif
 
 // WIRE_HAS_END means Wire has end()


### PR DESCRIPTION
I changed the define names to prevent conflicts with existing project that might use the common define name `BUFFER_LENGTH`. This patch also allows the receiving and transmitting buffers to be defined seperately from eachother.

The header `Wire.h` now looks like:
```cpp
// Size of the twi transmit buffer in bytes
#ifndef ARDUINO_WIRE_TX_BUFFER_LENGTH
#define ARDUINO_WIRE_TX_BUFFER_LENGTH 32
#endif

// Size of the twi receive buffer in bytes
#ifndef ARDUINO_WIRE_RX_BUFFER_LENGTH
#define ARDUINO_WIRE_RX_BUFFER_LENGTH 32
#endif
```
to enable the mentioned features.